### PR TITLE
Update taz.md

### DIFF
--- a/content/pages/3dprinters/taz.md
+++ b/content/pages/3dprinters/taz.md
@@ -4,4 +4,4 @@ Author: Mike Henry
 # Temperature Settings
 
 * Bed: 110
-* Nozzle: 260
+* Nozzle: 240


### PR DESCRIPTION
The temperature listed on this page for Taz is incorrect for the settings that we usually use with HIPS.  It should be 240, instead of 260.
